### PR TITLE
Fix Header z-index

### DIFF
--- a/frontend/src/components/_shared/Header.tsx
+++ b/frontend/src/components/_shared/Header.tsx
@@ -35,7 +35,7 @@ export default function Header({
   return (
     <Disclosure
       as="nav"
-      className="sticky top-0 z-10"
+      className="sticky top-0 z-20"
       style={{ background: backgroundColor }}
     >
       <div className="container py-[24px]">

--- a/frontend/src/components/home/mainSection/DatasetsSection.tsx
+++ b/frontend/src/components/home/mainSection/DatasetsSection.tsx
@@ -72,8 +72,6 @@ export default function DatasetsSection({
     },
   ];
 
-  const chunkedDatasets = chunkArray(_datasets, 3);
-
   return (
     <div className="container py-[96px]">
       <div className="mx-auto text-center lg:max-w-[640px]">


### PR DESCRIPTION
Carouse was getting in front of header when scrolling:
![image](https://github.com/user-attachments/assets/a3f2c1a7-c14b-4af7-bc9f-3bbb9140fbd6)

Fixed with a small z-index adjustment