### PR TITLE
Metadata Schema Implementation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,8 +96,14 @@ CKANEXT__S3FILESTORE__HOST_NAME=http://minio:9000
 CKANEXT__AUTH__INCLUDE_FRONTEND_LOGIN_TOKEN=True
 
 # Extensions
-CKAN__PLUGINS="envvars image_view text_view activity auth s3filestore datastore datapusher resource_proxy"
 CKAN__HARVEST__MQ__TYPE=redis
 CKAN__HARVEST__MQ__HOSTNAME=redis
 CKAN__HARVEST__MQ__PORT=6379
 CKAN__HARVEST__MQ__REDIS_DB=1
+
+CKAN___SCHEMING__DATASET_SCHEMAS=ckanext.tdc:schemas/dataset.yaml
+CKAN___SCHEMING__GROUP_SCHEMAS="ckanext.tdc:schemas/topic.yaml ckanext.tdc:schemas/geography.yaml"
+CKAN___SCHEMING__ORGANIZATION_SCHEMAS="ckanext.tdc:schemas/organization.yaml"
+CKAN___SCHEMING__PRESETS="ckanext.tdc:schemas/presets.yaml"
+CKAN__DEFAULT__GROUP_TYPE=topic
+CKAN__PLUGINS="tdc hierarchy_display scheming_datasets scheming_groups scheming_organizations dcat envvars image_view text_view activity auth s3filestore datastore datapusher resource_proxy"

--- a/ckan/Dockerfile
+++ b/ckan/Dockerfile
@@ -3,14 +3,22 @@ FROM viderum/ckan:v2.11.0
 ENV CKAN_INI /srv/app/production.ini
 
 # Install any extensions needed by your CKAN instance
-RUN pip3 install -e 'git+https://github.com/datopian/ckanext-scheming.git@ckan-2.10#egg=ckanext-scheming' && \
-    pip3 install -r 'https://raw.githubusercontent.com/datopian/ckanext-scheming/ckan-2.10/test-requirements.txt' && \
+RUN pip3 install -e 'git+https://github.com/datopian/ckanext-scheming.git@27035f4#egg=ckanext-scheming' && \
+    pip3 install -r 'https://raw.githubusercontent.com/datopian/ckanext-scheming/27035f4/test-requirements.txt' && \
     pip3 install -r 'https://raw.githubusercontent.com/shubham-mahajan/ckanext-s3filestore/feature/r2support-ckan-2.11/requirements.txt' && \
-    pip3 install -e 'git+https://github.com/datopian/ckanext-auth.git@109ac1672cf458919e2736d95c516f43c6768021#egg=ckanext-auth' && \
     pip3 install -e 'git+https://github.com/shubham-mahajan/ckanext-s3filestore.git@feature/r2support-ckan-2.11#egg=ckanext-s3filestore' && \
-    pip3 install -e "git+https://github.com/transport-data/tdc-data-portal.git@80598beda6e7121d247b0a0893ff48d7e6af3632#egg=ckanext-tdc&subdirectory=src/ckanext-tdc"
+    pip3 install -e "git+https://github.com/transport-data/tdc-data-portal.git@80598beda6e7121d247b0a0893ff48d7e6af3632#egg=ckanext-tdc&subdirectory=src/ckanext-tdc" \
 
+## Auth
 RUN pip install --no-cache-dir -e git+https://github.com/datopian/ckanext-auth.git@v2.11#egg=ckanext-auth
+
+## DCAT
+RUN  pip3 install -e git+https://github.com/ckan/ckanext-dcat.git@v2.0.0#egg=ckanext-dcat && \
+    pip3 install -r https://raw.githubusercontent.com/ckan/ckanext-dcat/v2.0.0/requirements.txt
+
+## Hierarchy
+RUN  pip3 install -e git+https://github.com/ckan/ckanext-hierarchy.git@master#egg=ckanext-hierarchy && \
+    pip3 install -r https://raw.githubusercontent.com/ckan/ckanext-hierarchy/master/requirements.txt
     
 ## Install the 'patch' command
 USER root

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -22,14 +22,14 @@ FROM ckan/ckan-dev:2.11.0
 # will also require gather_consumer and fetch_consumer processes running (please see https://github.com/ckan/ckanext-harvest)
 
 ### Scheming ###
-#RUN  pip3 install -e 'git+https://github.com/ckan/ckanext-scheming.git@master#egg=ckanext-scheming'
+RUN  pip3 install -e 'git+https://github.com/ckan/ckanext-scheming.git@master#egg=ckanext-scheming'
 
 ### Pages ###
 #RUN  pip3 install -e git+https://github.com/ckan/ckanext-pages.git#egg=ckanext-pages
 
 ### DCAT ###
-#RUN  pip3 install -e git+https://github.com/ckan/ckanext-dcat.git@v0.0.6#egg=ckanext-dcat && \
-#     pip3 install -r https://raw.githubusercontent.com/ckan/ckanext-dcat/v0.0.6/requirements.txt
+RUN  pip3 install -e git+https://github.com/ckan/ckanext-dcat.git@v2.0.0#egg=ckanext-dcat && \
+    pip3 install -r https://raw.githubusercontent.com/ckan/ckanext-dcat/v2.0.0/requirements.txt
 
 # Clone the extension(s) your are writing for your own project in the `src` folder
 # to get them mounted in this image at runtime

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -31,6 +31,10 @@ RUN  pip3 install -e 'git+https://github.com/ckan/ckanext-scheming.git@master#eg
 RUN  pip3 install -e git+https://github.com/ckan/ckanext-dcat.git@v2.0.0#egg=ckanext-dcat && \
     pip3 install -r https://raw.githubusercontent.com/ckan/ckanext-dcat/v2.0.0/requirements.txt
 
+### Hierarchy ###
+RUN  pip3 install -e git+https://github.com/ckan/ckanext-hierarchy.git@master#egg=ckanext-hierarchy && \
+    pip3 install -r https://raw.githubusercontent.com/ckan/ckanext-hierarchy/master/requirements.txt
+
 # Clone the extension(s) your are writing for your own project in the `src` folder
 # to get them mounted in this image at runtime
 RUN pip install -r https://raw.githubusercontent.com/datopian/ckanext-s3filestore/ckan-2.10/requirements.txt && \

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -81,6 +81,8 @@ services:
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-qO", "/dev/null", "http://localhost:8983/solr/"]
+    ports:
+      - "8983:8983"
 
   redis:
     container_name: ckan-tdc-redis

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -78,6 +78,7 @@ services:
     image: ckan/ckan-solr:${SOLR_IMAGE_VERSION}
     volumes:
       - solr_data:/var/solr
+      - ./src/ckanext-tdc/solr/schema.xml:/opt/solr/server/solr/configsets/ckan/conf/managed-schema
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "wget", "-qO", "/dev/null", "http://localhost:8983/solr/"]

--- a/docs/metadata-schema/README.md
+++ b/docs/metadata-schema/README.md
@@ -16,7 +16,7 @@ The following entities are used in the TDC CKAN extension:
 
 The way the entities relate to each other is the following:
 
-![relationships](relationships.svg)
+![relationships](./relationships.svg)
 
 Note that:
 

--- a/docs/metadata-schema/README.md
+++ b/docs/metadata-schema/README.md
@@ -1,0 +1,795 @@
+# Metadata Schema
+
+## Entities
+
+The following entities are used in the TDC CKAN extension:
+
+| Name | Title | CKAN type |
+| ---- | ----- | --------- |
+| dataset | Dataset | [dataset](https://docs.ckan.org/en/2.11/user-guide.html#datasets-and-resources) |
+| resource | Resource | [resource](https://docs.ckan.org/en/2.11/user-guide.html#datasets-and-resources) |
+| organization | Organization | [organization](https://docs.ckan.org/en/2.11/maintaining/authorization.html#organizations) |
+| topic | Topic | default group |
+| geography | Geography | custom group with hierarchy |
+
+### Relationships
+
+The way the entities relate to each other is the following:
+
+![relationships](relationships.svg)
+
+Note that:
+
+1) A resource must belong to exactly one dataset, and multiple resources may belong to the same given dataset
+2) A dataset must belong to exactly one organization
+3) A dataset may belong to one or more topics and/or geographies
+4) Multiple datasets may belong to the same given organization, topic or geography
+
+### Customization
+
+This taxonomy is mostly what comes built-in into CKAN, except for the following customizations:
+
+- "Group" is renamed to "Topic"
+- "Geography" is a custom group type
+
+### Why geographies are configured as a CKAN custom group type
+
+- CKAN has a built-in "follower" system, which enables users to "follow" groups and receive notifications about them. We want to enable users to follow geographies or their interest.
+- [ckanext-hierarchy](https://github.com/ckan/ckanext-hierarchy) makes it possible to have parent and children groups. This is handy for regions and countries, which have a parent/children relationship.
+- The responses for group-related API endpoints will already include dataset count for regions and countries
+- With [ckanext-scheming](https://github.com/datopian/ckanext-scheming), we can create extra metadata fields for geographies
+
+## Schemas 
+
+### Dataset
+
+**JSON schema:** (dataset.yaml)[https://github.com/transport-data/tdc-data-portal/tree/main/src/ckanext-tdc/ckanext/tdc/schemas/dataset.yaml]
+
+Example of a request body to create a dataset:
+
+```json
+{
+  "title": "Testing API",
+  "name": "testing-api-63",
+  "notes": "testing",
+  "tags": [
+    {
+      "name": "test"
+    }
+  ],
+  "license_id": "CC-SA",
+  "owner_org": "this-is-my-new-organization",
+  "temporal_coverage_start": "2024-01-01",
+  "temporal_coverage_end": "2024-02-01",
+  "geographies": [
+    "br"
+  ],
+  "tdc_category": "public",
+  "sources": [
+    {
+      "title": "My source",
+      "url": "https://datopian.com"
+    }
+  ],
+  "overview_text": "Testing",
+  "language": "en",
+  "is_archived": false,
+  "sectors": ["aviation"],
+  "modes": ["car"],
+  "services": ["passenger"],
+  "frequency": "annually"
+}`
+```
+
+#### Title
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| title | string | Yes | Yes | N/A |
+
+Title of the dataset as shown to users.
+
+**Example:**
+
+```json
+{
+    "title": "My title"
+}
+```
+
+#### URL
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| name | string | Yes | No | N/A |
+
+Usually it's the sluggified version of the dataset's title. Used in URLs.
+
+**Example:**
+
+```json
+{
+    "name": "my-title"
+}
+```
+
+#### Description
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| notes | markdown | Yes | Yes | N/A |
+
+Description of the dataset. It supports markdown formatting.
+
+**Example:**
+
+```json
+{
+    "notes": "My dataset's description"
+}
+```
+
+#### Keywords
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| tags | {"name": "Tag name"}[] | No | Yes | N/A |
+
+Keywords that help to describe the dataset.
+
+**Example:**
+
+```json
+{
+    "tags": [{"name": "keyword"}]
+}
+```
+
+#### License
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| license_id | string | No | Yes | N/A |
+
+License attached to the dataset. For options, see https://docs.ckan.org/en/2.11/api/index.html#ckan.logic.action.get.license_list.
+
+**Example:**
+
+```json
+{
+    "license_id": "CC-SA"
+}
+```
+
+#### Organization
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| owner_org | string | Yes | Yes | N/A |
+
+Organization the dataset belongs to.
+
+**Example:**
+
+```json
+{
+    "owner_org": "my-organization"
+}
+```
+
+#### Reference period
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| temporal_coverage_start and temporal_coverage_end | No | No | Yes | N/A |
+
+What time window the data in the dataset covers.
+
+**Example:**
+
+```json
+{
+    "temporal_coverage_start": "2024-01-01",
+    "temporal_coverage_end": "2024-02-01"
+}
+```
+
+#### Geographies
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| geographies | string[] | No | Yes | N/A |
+
+List of countries the dataset is associated with. Regions are calculated automatically based on the chosen countries.
+
+**Example:**
+
+```json
+{
+    "geographies": ["br"]
+}
+```
+
+#### TDC category
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| tdc_category | public OR community OR tdc_formatted OR tdc_harmonized | Yes | No | public |
+
+Defines the current category for this dateset, which can be Public Data, Community Data, TDC Formatted or TDC Harmonized.
+
+**Example:**
+
+```json
+{
+    "tdc_category": "public"
+}
+```
+
+#### Sources
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| sources | {"title": string, "url ": string}[] | No | Yes | N/A |
+
+Sources for this dataset.
+
+**Example:**
+
+```json
+{
+    "sources": [{
+        "title": "My source",
+        "url": "https://datopian.com"
+    }]
+}
+```
+
+#### Topics
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| topics | string[] | No | No | N/A |
+
+Topics associated with the dataset.
+
+**Example:**
+
+```json
+{
+    "topics": ["my-topic"]
+}
+```
+
+#### Overview
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| overview_text | markdown | No | No | N/A |
+
+This is the text that appears on the LHS of the metadata tab on the dataset page. Note that it supports markdown formatting.
+
+**Example:**
+
+```json
+{
+    "overview_text": "Some notes about my dataset"
+}
+```
+
+#### Language
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| language | string | No | Yes | N/A |
+
+Language (ISO 639-1 code) of the dataset.
+
+**Example:**
+
+```json
+{
+    "language": "en"
+}
+```
+
+#### Contributors
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| contributors | User[] | No | No | N/A |
+
+This field keeps track of which users got involved with a dataset. **It is autogenerated and cannot be set via API.**
+
+#### Is archived
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| is_archived | boolean | No | No | false |
+
+Whether the dataset is archived or not. Defaults to not archived.
+
+**Example:**
+
+```json
+{
+    "is_archived": true
+}
+```
+
+#### Sectors
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| sectors | string[] | No | No | N/A |
+
+Sectors the dataset is associated with.
+
+**Example:**
+
+```json
+{
+    "sectors": ["aviation"]
+}
+```
+
+#### Modes
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| modes | string[] | No | No | N/A |
+
+Transport modes the dataset is associated with.
+
+**Example:**
+
+```json
+{
+    "modes": ["bus"]
+}
+```
+
+#### Services
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| services | string[] | No | No | N/A |
+
+Services the dataset is associated with. It can be "freight", "passenger" or both.
+
+**Example:**
+
+```json
+{
+    "services": ["passenger"]
+}
+```
+
+#### Update frequency
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| frequency | string | No | No | N/A |
+
+Expected update frequency of this dataset.
+
+**Example:**
+
+```json
+{
+    "frequency": "annually"
+}
+```
+
+#### Indicator
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| indicator | string | No | No | N/A |
+
+Indicator of the dataset.
+
+**Example:**
+
+```json
+{
+    "indicator": "Air freight"
+}
+```
+
+#### Units
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| units | string[] | No | No | N/A |
+
+Units used in the dataset.
+
+**Example:**
+
+```json
+{
+    "units": ["tonnes"]
+}
+```
+
+#### Dimensioning
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| dimensioning | string | No | No | N/A |
+
+Dimensioning used in the dataset.
+
+**Example:**
+
+```json
+{
+    "dimensioning": "registrations by type"
+}
+```
+
+#### Related datasets
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| related_datasets | string[] | No | No | N/A |
+
+This field is used to support TDC Formatted datasets. The value should be a list of dataset ids.
+
+**Example:**
+
+```json
+{
+    "related_datasets": ["related-dataset-id"]
+}
+```
+
+### Resource
+
+**JSON schema:** (dataset.yaml)[https://github.com/transport-data/tdc-data-portal/tree/main/src/ckanext-tdc/ckanext/tdc/schemas/dataset.yaml]
+
+Example of a request body to create a resource:
+
+```json
+{
+  "package_id": "291b4b34-5ba9-446b-a0cd-b72af340db42",
+  "url": "https://google.com",
+  "name": "file.csv",
+  "format": "csv",
+  "resource_type": "data"
+}`
+```
+
+#### URL
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| url | string | Yes | No | N/A |
+
+URL of the data file.
+
+**Example:**
+
+```json
+{
+    "url": "https://storage.com/my-data.csv"
+}
+```
+
+#### Name
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| name | string | Yes | No | N/A |
+
+Name of the resource, as shown to users.
+
+**Example:**
+
+```json
+{
+    "name": "my-data.csv"
+}
+```
+
+#### Format
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| format | string | Yes | No | N/A |
+
+File format/extension of the resource.
+
+**Example:**
+
+```json
+{
+    "format": "csv"
+}
+```
+
+#### Type
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| resource_type | data OR documentation | Yes | No | N/A |
+
+Description
+
+**Example:**
+
+```json
+{
+    "type": "data"
+}
+```
+
+### Organization
+
+**JSON schema:** (organization.yaml)[https://github.com/transport-data/tdc-data-portal/tree/main/src/ckanext-tdc/ckanext/tdc/schemas/organization.yaml]
+
+Example of a request body to create a organization:
+
+```json
+{
+  "title": "My Organization",
+  "name": "my-organization",
+  "notes": "Description",
+  "email": "contact@datopian.com",
+  "url": "https://datopian.com"
+}
+```
+
+#### Title
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| title | string | Yes | Yes | N/A |
+
+Title of the organization, as shown to the users.
+
+**Example:**
+
+```json
+{
+    "title": "My Organization"
+}
+```
+
+#### Name
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| name | string | Yes | No | N/A |
+
+Usually a sluggified version of the title. Used in URLs.
+
+**Example:**
+
+```json
+{
+    "name": "my-organization"
+}
+```
+
+#### Description
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| notes | markdown | No | No | N/A |
+
+Description of the organization.
+
+**Example:**
+
+```json
+{
+    "notes": "My organization is awesome."
+}
+```
+
+#### Email
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| email | string | No | No | N/A |
+
+Email to contact the organization.
+
+**Example:**
+
+```json
+{
+    "email": "contact@datopian.com"
+}
+```
+
+#### Website URL
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| url | string | No | No | N/A |
+
+URL pointing to the website of the organization.
+
+**Example:**
+
+```json
+{
+    "url": "https://myorg.com"
+}
+```
+
+### Topic
+
+**JSON schema:** (topic.yaml)[https://github.com/transport-data/tdc-data-portal/tree/main/src/ckanext-tdc/ckanext/tdc/schemas/topic.yaml]
+
+Example of a request body to create a topic:
+
+```json
+{
+  "title": "My Topic",
+  "name": "my-topic",
+  "notes": "Description",
+  "url": "https://storage.com/topic.png",
+  "type": "topic"
+}
+```
+
+#### Title
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| title | string | Yes | Yes | N/A |
+
+Title of the topic, as shown to the users.
+
+**Example:**
+
+```json
+{
+    "title": "My Topic"
+}
+```
+
+#### Name
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| name | string | Yes | No | N/A |
+
+Usually a sluggified version of the title. Used in URLs.
+
+**Example:**
+
+```json
+{
+    "name": "my-topic"
+}
+```
+
+#### Description
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| notes | markdown | No | No | N/A |
+
+Description of the topic.
+
+**Example:**
+
+```json
+{
+    "notes": "My topic is awesome."
+}
+```
+
+#### Image URL
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| url | string | No | No | N/A |
+
+URL pointing to the image file for the topic.
+
+**Example:**
+
+```json
+{
+    "url": "https://storage.com/image.png"
+}
+```
+
+### Geography
+
+**JSON schema:** (geography.yaml)[https://github.com/transport-data/tdc-data-portal/tree/main/src/ckanext-tdc/ckanext/tdc/schemas/geography.yaml]
+
+Example of a request body to create a geography:
+
+```json
+{
+  "title": "Brazil",
+  "name": "br",
+  "geography_type": "country",
+  "type": "grography",
+  "groups": [{"name": "sa"}]
+}
+```
+
+#### Title
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| title | string | Yes | No | N/A |
+
+Title of the geography, as shown to the users.
+
+**Example:**
+
+```json
+{
+    "title": "Brazil"
+}
+```
+
+#### Name
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| name | string | Yes | No | N/A |
+
+Code for the geography.
+
+**Example:**
+
+```json
+{
+    "name": "br"
+}
+```
+
+#### Geography Type
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| geography_type | country OR region | Yes | No | N/A |
+
+Description
+
+**Example:**
+
+```json
+{
+    "geography_type": "country"
+}
+```
+
+#### Parents
+
+| API field name | Type | Required | DCAT-AP field | Default value |
+| -- | -- | -- | -- | -- |
+| groups | {"name": string}[] | No | No | N/A |
+
+When creating countries, users can specify which regions are the parents of the country using this field.
+
+**Example:**
+
+```json
+{
+    "groups": [{"name": "sa"}]
+}
+```
+
+## Prerequisites
+
+The following environment variables must be set:
+
+```bash
+CKAN___SCHEMING__DATASET_SCHEMAS=ckanext.tdc:schemas/dataset.yaml
+CKAN___SCHEMING__GROUP_SCHEMAS="ckanext.tdc:schemas/topic.yaml ckanext.tdc:schemas/geography.yaml"
+CKAN___SCHEMING__ORGANIZATION_SCHEMAS="ckanext.tdc:schemas/organization.yaml"
+CKAN___SCHEMING__PRESETS="ckanext.tdc:schemas/presets.yaml"
+CKAN__DEFAULT__GROUP_TYPE=topic
+CKAN__PLUGINS="tdc hierarchy_display scheming_datasets scheming_groups scheming_organizations dcat envvars image_view text_view activity auth s3filestore datastore datapusher resource_proxy"
+```

--- a/docs/metadata-schema/relationships.svg
+++ b/docs/metadata-schema/relationships.svg
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Error><Code>AccessDenied</Code><Message>Request has expired</Message><Expires>2024-09-08T20:33:22Z</Expires><ServerTime>2024-09-09T04:33:21Z</ServerTime><RequestId>7S76XHQ16ZJ0MWHD</RequestId><HostId>whJR6fIAc5ghoXmcQ+H4sd7U2r4ftfNBTtYFS/Yt1mIA0qaScvK8V4cSyM/0gxXuyq4AFIIOQK0=</HostId></Error>

--- a/integration-tests/cypress/e2e/ckan-classic-api.cy.js
+++ b/integration-tests/cypress/e2e/ckan-classic-api.cy.js
@@ -102,7 +102,9 @@ describe('CKAN Classic API Are Working', () => {
       headers: headers,
       body: {
         name: packageName,
-        owner_org: orgName
+        owner_org: orgName,
+        tdc_category: "public",
+        notes: "Description"
       }
     }).then((resp) => {
       cy.log(resp.body)

--- a/src/ckanext-tdc/ckanext/tdc/logic/action.py
+++ b/src/ckanext-tdc/ckanext/tdc/logic/action.py
@@ -1,0 +1,105 @@
+from ckan.plugins import toolkit as tk
+
+import logging
+log = logging.getLogger(__name__)
+
+
+def _fix_topics_field(data_dict):
+    groups = data_dict.get("groups", None)
+    if groups is not None and len(groups) > 0:
+        def is_topic(group):
+            group_type = group.get("type", None)
+            return group_type is None or group_type == "topic" or group_type == "group"
+
+        topics = list(filter(lambda x: is_topic(x), groups))
+        topic_names = [x.get("name") for x in topics]
+        data_dict["topics"] = topic_names
+    else:
+        data_dict["topics"] = []
+
+
+def _fix_geographies_field(data_dict):
+    """
+    When "geographies" field is provided, add dataset
+    to geographies and regions groups
+    """
+    geography_names = data_dict.get("geographies", None)
+
+    if geography_names is not None and len(geography_names) > 0:
+        countries = []
+        regions = []
+
+        priviliged_context = {"ignore_auth": True}
+
+        group_list_action = tk.get_action("group_list")
+        group_list_data_dict = {
+                "type": "geography",
+                "groups": geography_names,
+                "include_extras": True,
+                "all_fields": True,
+                "include_groups": True
+                }
+        group_list = group_list_action(priviliged_context, group_list_data_dict)
+
+        for group in group_list:
+            geography_type = group.get("geography_type")
+            if geography_type == "country":
+                group_name = group.get("name")
+                parent_groups = group.get("groups")
+                region_names = list([x.get("name") for x in parent_groups])
+
+                countries.append(group_name)
+                regions.extend(region_names)
+
+        countries = list(set(countries))
+        regions = list(set(regions))
+
+        geography_groups = [{"name": x, "type": "geography"} for x in countries + regions]
+        groups = data_dict.get("groups", [])
+        groups += geography_groups
+        data_dict["groups"] = groups
+        data_dict["geographies"] = countries
+        data_dict["regions"] = regions
+
+
+@tk.chained_action
+def package_create(up_func, context, data_dict):
+    _fix_geographies_field(data_dict)
+    _fix_topics_field(data_dict)
+    result = up_func(context, data_dict)
+    return result
+
+
+@tk.chained_action
+def package_update(up_func, context, data_dict):
+    _fix_geographies_field(data_dict)
+    _fix_topics_field(data_dict)
+    result = up_func(context, data_dict)
+    return result
+
+
+@tk.chained_action
+def package_patch(up_func, context, data_dict):
+    _fix_geographies_field(data_dict)
+    _fix_topics_field(data_dict)
+    result = up_func(context, data_dict)
+    return result
+
+
+@tk.chained_action
+@tk.side_effect_free
+def package_search(up_func, context, data_dict):
+    include_archived_param = data_dict.get("include_archived", "false")
+    include_archived = tk.asbool(include_archived_param)
+
+    if not include_archived:
+        if "fq" not in data_dict:
+            data_dict["fq"] = ""
+
+        data_dict["fq"] += " -is_archived:(true)"
+
+    if "include_archived" in data_dict:
+        del data_dict["include_archived"]
+
+    result = up_func(context, data_dict)
+    return result

--- a/src/ckanext-tdc/ckanext/tdc/plugin.py
+++ b/src/ckanext-tdc/ckanext/tdc/plugin.py
@@ -1,9 +1,17 @@
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 
+import ckanext.tdc.logic.action as action
+
+import json
+import logging
+log = logging.getLogger(__name__)
+
+
 class TdcPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IConfigurer)
-    # plugins.implements(plugins.IActions)
+    plugins.implements(plugins.IActions)
+    plugins.implements(plugins.IPackageController, inherit=True)
 
     # IConfigurer
 
@@ -11,3 +19,33 @@ class TdcPlugin(plugins.SingletonPlugin):
         toolkit.add_template_directory(config_, 'templates')
         toolkit.add_public_directory(config_, 'public')
         toolkit.add_resource('fanstatic', 'tdc')
+
+    # IActions
+
+    def get_actions(self):
+        return {
+                "package_create": action.package_create,
+                "package_update": action.package_update,
+                "package_patch": action.package_patch,
+                "package_search": action.package_search
+                }
+
+    # IPackageController
+
+    def before_dataset_index(self, data_dict):
+        # This is a fix so that solr stores a list
+        # instead of a string for multivalued fields
+        multi_value_extra_fields = [
+                "topics",
+                "geographies",
+                "regions",
+                "sectors",
+                "modes",
+                "services"]
+        for field in multi_value_extra_fields:
+            value = data_dict.get(field, None)
+            if value is not None and isinstance(value, str):
+                new_value = json.loads(value)
+                if isinstance(new_value, list):
+                    data_dict[field] = new_value
+        return data_dict

--- a/src/ckanext-tdc/ckanext/tdc/plugin.py
+++ b/src/ckanext-tdc/ckanext/tdc/plugin.py
@@ -41,7 +41,8 @@ class TdcPlugin(plugins.SingletonPlugin):
                 "regions",
                 "sectors",
                 "modes",
-                "services"]
+                "services",
+                "contributors"]
         for field in multi_value_extra_fields:
             value = data_dict.get(field, None)
             if value is not None and isinstance(value, str):

--- a/src/ckanext-tdc/ckanext/tdc/plugin.py
+++ b/src/ckanext-tdc/ckanext/tdc/plugin.py
@@ -3,7 +3,7 @@ import ckan.plugins.toolkit as toolkit
 
 class TdcPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IConfigurer)
-    plugins.implements(plugins.IActions)
+    # plugins.implements(plugins.IActions)
 
     # IConfigurer
 

--- a/src/ckanext-tdc/ckanext/tdc/schemas/dataset.yaml
+++ b/src/ckanext-tdc/ckanext/tdc/schemas/dataset.yaml
@@ -8,72 +8,73 @@ dataset_fields:
   label: Title
   preset: title
   required: true
-  help_text: A descriptive title for the dataset.
+  help_text: Title of the dataset as shown to users.
 
 - field_name: name
   label: URL
   preset: dataset_slug
   form_placeholder: eg. my-dataset
+  required: true
+  help_text: Usually it's the sluggified version of the dataset's title. Used in URLs.
 
 - field_name: notes
   label: Description
-  required: true
   form_snippet: markdown.html
   help_text: A free-text account of the dataset.
+  required: true
+  help_text: Description of the dataset. It supports markdown formatting.
 
 - field_name: tag_string
   label: Keywords
   preset: tag_string_autocomplete
   form_placeholder: eg. economy, mental health, government
-  help_text: Keywords or tags describing the dataset. Use commas to separate multiple values.
+  help_text: Keywords that help to describe the dataset.
 
 - field_name: license_id
   label: License
   form_snippet: license.html
-  help_text: License definitions and additional information can be found at http://opendefinition.org/.
+  help_text: License attached to the dataset.
 
 - field_name: owner_org
   label: Organisation
   preset: dataset_organization
-  help_text: The CKAN organisation the dataset belongs to.
+  help_text: Organization the dataset belongs to.
 
-# Temporal coverage should be calculated based on
-# the resource's temporal coverage
-# - field_name: temporal_coverage
-#   label: Reference period
-#   repeating_subfields:
-#
-#     - field_name: start
-#       label: Start
-#       preset: dcat_date
-#
-#     - field_name: end
-#       label: End
-#       preset: dcat_date
-#   help_text: The temporal period or periods the dataset covers.
+- field_name: temporal_coverage_start
+  label: Reference period start
+  help_text: What time window the data in the dataset covers.
+  preset: dcat_date
 
-  # This field is kept only for DCAT compatibility
-  # Spatial coverage is determined by the geographies groups
-- field_name: spatial_coverage
-  label: Spatial coverage
+- field_name: temporal_coverage_end
+  label: Reference period end
+  help_text: What time window the data in the dataset covers.
+  preset: dcat_date
+
+- field_name: geographies
+  label: Geographies
+  preset: multiple_text
+  validators: ignore_missing scheming_multiple_text
+  output_validators: scheming_load_json
+
+# Only for indexing purposes
+- field_name: regions
+  label: Regions
   form_snippet: null
-  display_snippet: null
+  validators: ignore_missing scheming_multiple_text
+  output_validators: scheming_load_json
 
-  # Note: this will fall back to metadata_created if not present
-- field_name: issued
-  label: Release date
-  preset: dcat_date
-  help_text: Date of publication of the dataset.
-
-  # Note: this will fall back to metadata_modified if not present
-- field_name: modified
-  label: Modification date
-  preset: dcat_date
-  help_text: Most recent date on which the dataset was changed, updated or modified.
+# Only for indexing purposes
+- field_name: topics
+  label: Topics
+  form_snippet: null
+  validators: ignore_missing scheming_multiple_text
+  output_validators: scheming_load_json
 
 - field_name: tdc_category
   label: Category
   preset: select
+  required: true
+  default: public
   choices:
   - value: public
     label: Public Data
@@ -106,14 +107,16 @@ dataset_fields:
 - field_name: is_archived
   label: Is archived
   preset: select
+  validators: boolean_validator
+  output_validators: boolean_validator
   choices:
     - value: false
       label: No
     - value: true
       label: Yes
 
-- field_name: sector
-  label: Sector
+- field_name: sectors
+  label: Sectors
   preset: multiple_select
   choices:
     - value: road
@@ -126,8 +129,8 @@ dataset_fields:
       label: Aviation
 
   # NOTE: these options should be limited by Sector
-- field_name: mode
-  label: Mode
+- field_name: modes
+  label: Modes
   preset: multiple_select
   choices:
     - value: car
@@ -143,8 +146,8 @@ dataset_fields:
     - value: other
       label: Other
 
-- field_name: service
-  label: Service
+- field_name: services
+  label: Services
   preset: multiple_select
   choices:
     - value: passenger
@@ -176,56 +179,51 @@ dataset_fields:
   - value: not_planned
     label: Not Planned
 
-# Indicator should be a custom tag vocabulary
+- field_name: indicator
+  label: Indicator
+
+- field_name: units
+  label: Units
+  preset: multiple_text
+
+- field_name: dimensioning
+  label: Dimensioning
 
 - field_name: related_datasets
   label: Related datasets
   preset: multiple_text
+  validators: ignore_missing
+
+- field_name: related_datasets
+  label: Related datasets
+  preset: multiple_text
+  validators: ignore_missing
 
 resource_fields:
 
 - field_name: url
   label: URL
   preset: resource_url_upload
+  required: true
 
 - field_name: name
   label: Name
+  required: true
   form_placeholder:
   help_text: A descriptive title for the resource.
 
-- field_name: description
-  label: Description
-  form_snippet: markdown.html
-  help_text: A free-text account of the resource.
-
 - field_name: format
+  required: true
   label: Format
   preset: resource_format_autocomplete
   help_text: File format. If not provided it will be guessed.
 
-- field_name: type
+- field_name: resource_type
   label: Type
   preset: select
+  required: true
   choices:
     - value: data
       label: Data
     - value: documentation
       label: Documentation
-
-- field_name: unit
-  label: Unit
-
-- field_name: dimensioning
-  label: Dimensioning
-
-- field_name: temporal_coverage
-  label: Reference period
-  repeating_subfields:
-    - field_name: start
-      label: Start
-      preset: dcat_date
-
-    - field_name: end
-      label: End
-      preset: dcat_date
-  

--- a/src/ckanext-tdc/ckanext/tdc/schemas/dataset.yaml
+++ b/src/ckanext-tdc/ckanext/tdc/schemas/dataset.yaml
@@ -1,0 +1,231 @@
+scheming_version: 2
+dataset_type: dataset
+about_url: http://github.com/ckan/ckanext-dcat
+
+dataset_fields:
+
+- field_name: title
+  label: Title
+  preset: title
+  required: true
+  help_text: A descriptive title for the dataset.
+
+- field_name: name
+  label: URL
+  preset: dataset_slug
+  form_placeholder: eg. my-dataset
+
+- field_name: notes
+  label: Description
+  required: true
+  form_snippet: markdown.html
+  help_text: A free-text account of the dataset.
+
+- field_name: tag_string
+  label: Keywords
+  preset: tag_string_autocomplete
+  form_placeholder: eg. economy, mental health, government
+  help_text: Keywords or tags describing the dataset. Use commas to separate multiple values.
+
+- field_name: license_id
+  label: License
+  form_snippet: license.html
+  help_text: License definitions and additional information can be found at http://opendefinition.org/.
+
+- field_name: owner_org
+  label: Organisation
+  preset: dataset_organization
+  help_text: The CKAN organisation the dataset belongs to.
+
+# Temporal coverage should be calculated based on
+# the resource's temporal coverage
+# - field_name: temporal_coverage
+#   label: Reference period
+#   repeating_subfields:
+#
+#     - field_name: start
+#       label: Start
+#       preset: dcat_date
+#
+#     - field_name: end
+#       label: End
+#       preset: dcat_date
+#   help_text: The temporal period or periods the dataset covers.
+
+  # This field is kept only for DCAT compatibility
+  # Spatial coverage is determined by the geographies groups
+- field_name: spatial_coverage
+  label: Spatial coverage
+  form_snippet: null
+  display_snippet: null
+
+  # Note: this will fall back to metadata_created if not present
+- field_name: issued
+  label: Release date
+  preset: dcat_date
+  help_text: Date of publication of the dataset.
+
+  # Note: this will fall back to metadata_modified if not present
+- field_name: modified
+  label: Modification date
+  preset: dcat_date
+  help_text: Most recent date on which the dataset was changed, updated or modified.
+
+- field_name: tdc_category
+  label: Category
+  preset: select
+  choices:
+  - value: public
+    label: Public Data
+  - value: community
+    label: Community Data
+  - value: tdc_formatted
+    label: TDC Formatted
+  - value: tdc_harmonized
+    label: TDC Harmonized
+
+- field_name: sources
+  label: Sources
+  repeating_subfields:
+  - field_name: title
+    label: Title
+    required: true
+  - field_name: url
+    label: Link
+
+- field_name: overview_text
+  label: Overview Text
+  preset: markdown
+
+# As options, use https://id.loc.gov/vocabulary/iso639-1.html
+# or https://en.wikipedia.org/wiki/List_of_ISO_639_language_codes
+# See https://www.w3.org/TR/vocab-dcat-3/#Property:resource_language
+- field_name: language
+  label: Language
+
+- field_name: is_archived
+  label: Is archived
+  preset: select
+  choices:
+    - value: false
+      label: No
+    - value: true
+      label: Yes
+
+- field_name: sector
+  label: Sector
+  preset: multiple_select
+  choices:
+    - value: road
+      label: Road
+    - value: rail
+      label: Rail
+    - value: water_transportation
+      label: Water Transportation
+    - value: aviation
+      label: Aviation
+
+  # NOTE: these options should be limited by Sector
+- field_name: mode
+  label: Mode
+  preset: multiple_select
+  choices:
+    - value: car
+      label: Car
+    - value: motorised_2w
+      label: Motorised 2W
+    - value: motorised_3w
+      label: Motorised 3W
+    - value: bus
+      label: Bus
+    - value: good_vehicles
+      label: Good Vehicles
+    - value: other
+      label: Other
+
+- field_name: service
+  label: Service
+  preset: multiple_select
+  choices:
+    - value: passenger
+      label: Passenger
+    - value: freight
+      label: Freight
+        
+  # See http://publications.europa.eu/resource/authority/frequency
+- field_name: frequency
+  label: Update frequency
+  preset: select
+  choices:
+  - value: annually
+    label: Annually
+  - value: biannually
+    label: Biannually
+  - value: quarterly
+    label: Quarterly
+  - value: monthly
+    label: Monthly
+  - value: weekly
+    label: Weekly
+  - value: daily
+    label: Daily
+  - value: hourly
+    label: Hourly
+  - value: as_needed
+    label: As Needed
+  - value: not_planned
+    label: Not Planned
+
+# Indicator should be a custom tag vocabulary
+
+- field_name: related_datasets
+  label: Related datasets
+  preset: multiple_text
+
+resource_fields:
+
+- field_name: url
+  label: URL
+  preset: resource_url_upload
+
+- field_name: name
+  label: Name
+  form_placeholder:
+  help_text: A descriptive title for the resource.
+
+- field_name: description
+  label: Description
+  form_snippet: markdown.html
+  help_text: A free-text account of the resource.
+
+- field_name: format
+  label: Format
+  preset: resource_format_autocomplete
+  help_text: File format. If not provided it will be guessed.
+
+- field_name: type
+  label: Type
+  preset: select
+  choices:
+    - value: data
+      label: Data
+    - value: documentation
+      label: Documentation
+
+- field_name: unit
+  label: Unit
+
+- field_name: dimensioning
+  label: Dimensioning
+
+- field_name: temporal_coverage
+  label: Reference period
+  repeating_subfields:
+    - field_name: start
+      label: Start
+      preset: dcat_date
+
+    - field_name: end
+      label: End
+      preset: dcat_date
+  

--- a/src/ckanext-tdc/ckanext/tdc/schemas/dataset.yaml
+++ b/src/ckanext-tdc/ckanext/tdc/schemas/dataset.yaml
@@ -185,6 +185,9 @@ dataset_fields:
 - field_name: units
   label: Units
   preset: multiple_text
+  validators: ignore_missing scheming_valid_json_object
+  output_validators: scheming_load_json
+
 
 - field_name: dimensioning
   label: Dimensioning
@@ -192,12 +195,8 @@ dataset_fields:
 - field_name: related_datasets
   label: Related datasets
   preset: multiple_text
-  validators: ignore_missing
-
-- field_name: related_datasets
-  label: Related datasets
-  preset: multiple_text
-  validators: ignore_missing
+  validators: ignore_missing scheming_multiple_text
+  output_validators: scheming_load_json
 
 resource_fields:
 

--- a/src/ckanext-tdc/ckanext/tdc/schemas/dataset.yaml
+++ b/src/ckanext-tdc/ckanext/tdc/schemas/dataset.yaml
@@ -198,6 +198,13 @@ dataset_fields:
   validators: ignore_missing scheming_multiple_text
   output_validators: scheming_load_json
 
+- field_name: contributors
+  label: Contributors
+  preset: multiple_text
+  form_snippet: null
+  validators: ignore_missing scheming_multiple_text
+  output_validators: scheming_load_json
+
 resource_fields:
 
 - field_name: url

--- a/src/ckanext-tdc/ckanext/tdc/schemas/geography.yaml
+++ b/src/ckanext-tdc/ckanext/tdc/schemas/geography.yaml
@@ -1,5 +1,5 @@
 scheming_version: 2
-group_type: topic
+group_type: geography
 
 fields:
 - field_name: title
@@ -22,7 +22,7 @@ fields:
   label: Image URL
   form_placeholder: http://example.com/my-image.jpg
 
-- field_name: type
+- field_name: geography_type
   label: Type
   preset: select
   choices:
@@ -30,3 +30,9 @@ fields:
       name: Country
     - value: region
       name: Region
+
+- field_name: not_used
+  label: Parent organization
+  display_snippet: null
+  form_snippet: org_hierarchy.html
+  validators: ignore_missing

--- a/src/ckanext-tdc/ckanext/tdc/schemas/geography.yaml
+++ b/src/ckanext-tdc/ckanext/tdc/schemas/geography.yaml
@@ -24,6 +24,9 @@ fields:
     - value: region
       name: Region
 
+- field_name: geography_shape
+  label: Geography Shape
+
 - field_name: not_used
   label: Parent organization
   display_snippet: null

--- a/src/ckanext-tdc/ckanext/tdc/schemas/geography.yaml
+++ b/src/ckanext-tdc/ckanext/tdc/schemas/geography.yaml
@@ -1,0 +1,32 @@
+scheming_version: 2
+group_type: topic
+
+fields:
+- field_name: title
+  label: Name
+  validators: ignore_missing unicode_safe
+  form_snippet: large_text.html
+  form_attrs:
+    data-module: slug-preview-target
+
+- field_name: name
+  label: URL
+  validators: not_empty unicode_safe name_validator group_name_validator
+  form_snippet: slug.html
+
+- field_name: notes
+  label: Description
+  form_snippet: markdown.html
+
+- field_name: url
+  label: Image URL
+  form_placeholder: http://example.com/my-image.jpg
+
+- field_name: type
+  label: Type
+  preset: select
+  choices:
+    - value: country
+      name: Country
+    - value: region
+      name: Region

--- a/src/ckanext-tdc/ckanext/tdc/schemas/geography.yaml
+++ b/src/ckanext-tdc/ckanext/tdc/schemas/geography.yaml
@@ -14,17 +14,10 @@ fields:
   validators: not_empty unicode_safe name_validator group_name_validator
   form_snippet: slug.html
 
-- field_name: notes
-  label: Description
-  form_snippet: markdown.html
-
-- field_name: url
-  label: Image URL
-  form_placeholder: http://example.com/my-image.jpg
-
 - field_name: geography_type
   label: Type
   preset: select
+  required: true
   choices:
     - value: country
       name: Country

--- a/src/ckanext-tdc/ckanext/tdc/schemas/organization.yaml
+++ b/src/ckanext-tdc/ckanext/tdc/schemas/organization.yaml
@@ -16,7 +16,6 @@ fields:
   label: URL
   validators: not_empty unicode_safe name_validator group_name_validator
   form_snippet: slug.html
-  form_placeholder: my-theme
   
 - field_name: notes
   label: Description
@@ -28,5 +27,5 @@ fields:
   display_snippet: email.html
   
 - field_name: url
-  label: URL
+  label: Website URL
   display_snippet: link.html

--- a/src/ckanext-tdc/ckanext/tdc/schemas/organization.yaml
+++ b/src/ckanext-tdc/ckanext/tdc/schemas/organization.yaml
@@ -1,0 +1,32 @@
+scheming_version: 2
+organization_type: organization
+description: >
+  An organization schema that implements the properties supported
+  by default in the dct:publisher property of a dcat:Dataset
+
+fields:
+    
+- field_name: title
+  label: Name
+  validators: ignore_missing unicode_safe
+  form_snippet: large_text.html
+  form_attrs: {data-module: slug-preview-target}
+  
+- field_name: name
+  label: URL
+  validators: not_empty unicode_safe name_validator group_name_validator
+  form_snippet: slug.html
+  form_placeholder: my-theme
+  
+- field_name: notes
+  label: Description
+  form_snippet: markdown.html
+  form_placeholder: A little information about this organization.
+  
+- field_name: email
+  label: Email
+  display_snippet: email.html
+  
+- field_name: url
+  label: URL
+  display_snippet: link.html

--- a/src/ckanext-tdc/ckanext/tdc/schemas/presets.yaml
+++ b/src/ckanext-tdc/ckanext/tdc/schemas/presets.yaml
@@ -1,0 +1,108 @@
+scheming_presets_version: 1
+
+presets:
+
+- preset_name: dcat_date
+  values:
+    # Note: use datetime.html or datetime_tz.html if you want to inclue an input for time
+    form_snippet: date.html
+    display_snippet: dcat_date.html
+    validators: ignore_missing dcat_date convert_to_json_if_datetime
+- preset_name: title
+  values:
+    validators: if_empty_same_as(name) unicode_safe
+    form_snippet: large_text.html
+    form_attrs:
+      data-module: slug-preview-target
+- preset_name: dataset_slug
+  values:
+    validators: not_empty unicode_safe name_validator package_name_validator
+    form_snippet: slug.html
+- preset_name: tag_string_autocomplete
+  values:
+    validators: ignore_missing tag_string_convert
+    classes:
+    - control-full
+    form_attrs:
+      data-module: autocomplete
+      data-module-tags: ''
+      data-module-source: "/api/2/util/tag/autocomplete?incomplete=?"
+      class: ''
+- preset_name: dataset_organization
+  values:
+    validators: owner_org_validator unicode_safe
+    form_snippet: organization.html
+- preset_name: resource_url_upload
+  values:
+    validators: ignore_missing unicode_safe remove_whitespace
+    form_snippet: upload.html
+    form_placeholder: http://example.com/my-data.csv
+    upload_field: upload
+    upload_clear: clear_upload
+    upload_label: File
+- preset_name: organization_url_upload
+  values:
+    validators: ignore_missing unicode_safe remove_whitespace
+    form_snippet: organization_upload.html
+    form_placeholder: http://example.com/my-data.csv
+- preset_name: resource_format_autocomplete
+  values:
+    validators: if_empty_guess_format ignore_missing clean_format unicode_safe
+    form_placeholder: eg. CSV, XML or JSON
+    form_attrs:
+      data-module: autocomplete
+      data-module-source: "/api/2/util/resource/format_autocomplete?incomplete=?"
+- preset_name: select
+  values:
+    form_snippet: select.html
+    display_snippet: select.html
+    validators: scheming_required scheming_choices
+- preset_name: multiple_checkbox
+  values:
+    form_snippet: multiple_checkbox.html
+    display_snippet: multiple_choice.html
+    validators: scheming_multiple_choice
+    output_validators: scheming_multiple_choice_output
+- preset_name: multiple_select
+  values:
+    form_snippet: multiple_select.html
+    display_snippet: multiple_choice.html
+    validators: scheming_multiple_choice
+    output_validators: scheming_multiple_choice_output
+- preset_name: date
+  values:
+    form_snippet: date.html
+    display_snippet: date.html
+    validators: scheming_required isodate convert_to_json_if_date
+- preset_name: datetime
+  values:
+    form_snippet: datetime.html
+    display_snippet: datetime.html
+    validators: scheming_isodatetime convert_to_json_if_datetime
+- preset_name: datetime_tz
+  values:
+    form_snippet: datetime_tz.html
+    display_snippet: datetime_tz.html
+    validators: scheming_isodatetime_tz convert_to_json_if_datetime
+- preset_name: json_object
+  values:
+    validators: scheming_required scheming_valid_json_object
+    output_validators: scheming_load_json
+    form_snippet: json.html
+    display_snippet: json.html
+- preset_name: multiple_text
+  values:
+    form_snippet: multiple_text.html
+    display_snippet: multiple_text.html
+    validators: scheming_multiple_text
+    output_validators: scheming_load_json
+- preset_name: markdown
+  values:
+    form_snippet: markdown.html
+    display_snippet: markdown.html
+- preset_name: radio
+  values:
+    form_snippet: radio.html
+    display_snippet: select.html
+    validators: scheming_required scheming_choices
+

--- a/src/ckanext-tdc/ckanext/tdc/schemas/topic.yaml
+++ b/src/ckanext-tdc/ckanext/tdc/schemas/topic.yaml
@@ -1,0 +1,23 @@
+scheming_version: 2
+group_type: topic
+
+fields:
+- field_name: title
+  label: Name
+  validators: ignore_missing unicode_safe
+  form_snippet: large_text.html
+  form_attrs:
+    data-module: slug-preview-target
+
+- field_name: name
+  label: URL
+  validators: not_empty unicode_safe name_validator group_name_validator
+  form_snippet: slug.html
+
+- field_name: notes
+  label: Description
+  form_snippet: markdown.html
+
+- field_name: url
+  label: Image URL
+  form_placeholder: http://example.com/my-image.jpg

--- a/src/ckanext-tdc/solr/schema.xml
+++ b/src/ckanext-tdc/solr/schema.xml
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<!--
+     NB Please copy changes to this file into the multilingual schema:
+        ckanext/multilingual/solr/schema.xml
+-->
+
+<!-- We update the version when there is a backward-incompatible change to this
+schema. We used to use the `version` attribute for this but this is an internal
+attribute that should not be used so starting from CKAN 2.10 we use the `name`
+attribute with the form `ckan-X.Y` -->
+<schema name="ckan-2.11" version="1.6">
+
+<types>
+    <fieldType name="string" class="solr.StrField" sortMissingLast="true" omitNorms="true"/>
+    <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true" omitNorms="true"/>
+    <fieldtype name="binary" class="solr.BinaryField"/>
+    <fieldType name="int" class="solr.IntPointField" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="float" class="solr.FloatPointField" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="long" class="solr.LongPointField" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="double" class="solr.DoublePointField" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="pint" class="solr.IntPointField" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="pfloat" class="solr.FloatPointField" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="plong" class="solr.LongPointField" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="pdouble" class="solr.DoublePointField" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="date" class="solr.DatePointField" omitNorms="true" positionIncrementGap="0"/>
+    <fieldType name="pdate" class="solr.DatePointField" omitNorms="true" positionIncrementGap="0"/>
+
+    <fieldType name="pdates" class="solr.DatePointField" positionIncrementGap="0" multiValued="true"/>
+    <fieldType name="booleans" class="solr.BoolField" sortMissingLast="true" multiValued="true"/>
+    <fieldType name="pints" class="solr.IntPointField" positionIncrementGap="0" multiValued="true"/>
+    <fieldType name="pfloats" class="solr.FloatPointField" positionIncrementGap="0" multiValued="true"/>
+    <fieldType name="plongs" class="solr.LongPointField" positionIncrementGap="0" multiValued="true"/>
+    <fieldType name="pdoubles" class="solr.DoublePointField" positionIncrementGap="0" multiValued="true"/>
+
+    <fieldType name="text" class="solr.TextField" positionIncrementGap="100">
+        <analyzer type="index">
+            <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
+            <filter class="solr.FlattenGraphFilterFactory"/> <!-- required on index analyzers after graph filters -->
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.SnowballPorterFilterFactory" language="English" protected="protwords.txt"/>
+            <filter class="solr.ASCIIFoldingFilterFactory"/>
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+            <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+            <filter class="solr.SnowballPorterFilterFactory" language="English" protected="protwords.txt"/>
+            <filter class="solr.ASCIIFoldingFilterFactory"/>
+        </analyzer>
+    </fieldType>
+
+
+    <!-- A general unstemmed text field - good if one does not know the language of the field -->
+    <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100">
+        <analyzer type="index">
+            <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="0"/>
+            <filter class="solr.FlattenGraphFilterFactory"/> <!-- required on index analyzers after graph filters -->
+            <filter class="solr.LowerCaseFilterFactory"/>
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+            <filter class="solr.SynonymGraphFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+            <filter class="solr.WordDelimiterGraphFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="0"/>
+            <filter class="solr.LowerCaseFilterFactory"/>
+        </analyzer>
+    </fieldType>
+
+    <fieldType name="text_ngram" class="solr.TextField" positionIncrementGap="100">
+      <analyzer type="index">
+        <tokenizer class="solr.NGramTokenizerFactory" minGramSize="2" maxGramSize="10"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <filter class="solr.LowerCaseFilterFactory"/>
+      </analyzer>
+    </fieldType>
+
+</types>
+
+
+<fields>
+    <field name="index_id" type="string" indexed="true" stored="true" required="true" />
+    <field name="id" type="string" indexed="true" stored="true" required="true" />
+    <field name="site_id" type="string" indexed="true" stored="true" required="true" />
+    <field name="title" type="text" indexed="true" stored="true" />
+    <field name="title_ngram" type="text_ngram" indexed="true" stored="true" />
+    <field name="entity_type" type="string" indexed="true" stored="true" omitNorms="true" />
+    <field name="dataset_type" type="string" indexed="true" stored="true" />
+    <field name="state" type="string" indexed="true" stored="true" omitNorms="true" />
+    <field name="name" type="string" indexed="true" stored="true" omitNorms="true" />
+    <field name="name_ngram" type="text_ngram" indexed="true" stored="true" />
+    <field name="revision_id" type="string" indexed="true" stored="true" omitNorms="true" />
+    <field name="version" type="string" indexed="true" stored="true" />
+    <field name="url" type="string" indexed="true" stored="true" omitNorms="true" />
+    <field name="ckan_url" type="string" indexed="true" stored="true" omitNorms="true" />
+    <field name="download_url" type="string" indexed="true" stored="true" omitNorms="true" />
+    <field name="notes" type="text" indexed="true" stored="true"/>
+    <field name="author" type="text_general" indexed="true" stored="true" />
+    <field name="author_email" type="text_general" indexed="true" stored="true" />
+    <field name="maintainer" type="text_general" indexed="true" stored="true" />
+    <field name="maintainer_email" type="text_general" indexed="true" stored="true" />
+    <field name="license" type="string" indexed="true" stored="true" />
+    <field name="license_id" type="string" indexed="true" stored="true" />
+    <field name="tags" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="groups" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="organization" type="string" indexed="true" stored="true" multiValued="false"/>
+    <field name="extras_topics" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="extras_geographies" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="extras_regions" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="extras_sectors" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="extras_modes" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="extras_services" type="string" indexed="true" stored="true" multiValued="true"/>
+
+    <field name="capacity" type="string" indexed="true" stored="true" multiValued="false"/>
+    <field name="permission_labels" type="string" indexed="true" stored="false" multiValued="true"/>
+
+    <field name="res_name" type="text_general" indexed="true" stored="true" multiValued="true" />
+    <field name="res_description" type="text_general" indexed="true" stored="true" multiValued="true"/>
+    <field name="res_format" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="res_url" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="res_type" type="string" indexed="true" stored="true" multiValued="true"/>
+
+    <!-- catchall field, containing all other searchable text fields (implemented
+         via copyField further on in this schema  -->
+    <field name="text" type="text" indexed="true" stored="false" multiValued="true"/>
+    <field name="urls" type="text" indexed="true" stored="false" multiValued="true"/>
+
+    <field name="depends_on" type="text" indexed="true" stored="false" multiValued="true"/>
+    <field name="dependency_of" type="text" indexed="true" stored="false" multiValued="true"/>
+    <field name="derives_from" type="text" indexed="true" stored="false" multiValued="true"/>
+    <field name="has_derivation" type="text" indexed="true" stored="false" multiValued="true"/>
+    <field name="links_to" type="text" indexed="true" stored="false" multiValued="true"/>
+    <field name="linked_from" type="text" indexed="true" stored="false" multiValued="true"/>
+    <field name="child_of" type="text" indexed="true" stored="false" multiValued="true"/>
+    <field name="parent_of" type="text" indexed="true" stored="false" multiValued="true"/>
+    <field name="views_total" type="int" indexed="true" stored="false"/>
+    <field name="views_recent" type="int" indexed="true" stored="false"/>
+    <field name="resources_accessed_total" type="int" indexed="true" stored="false"/>
+    <field name="resources_accessed_recent" type="int" indexed="true" stored="false"/>
+
+    <field name="metadata_created" type="date" indexed="true" stored="true" multiValued="false"/>
+    <field name="metadata_modified" type="date" indexed="true" stored="true" multiValued="false"/>
+
+    <field name="indexed_ts" type="date" indexed="true" stored="true" default="NOW" multiValued="false"/>
+
+    <!-- Copy the title field into titleString, and treat as a string
+         (rather than text type).  This allows us to sort on the titleString -->
+    <field name="title_string" type="string" indexed="true" stored="false" />
+
+    <field name="data_dict" type="string" indexed="false" stored="true" />
+    <field name="validated_data_dict" type="string" indexed="false" stored="true" />
+
+    <field name="_version_" type="string" indexed="true" stored="true"/>
+
+    <dynamicField name="*_date" type="date" indexed="true" stored="true" multiValued="false"/>
+
+    <dynamicField name="extras_*" type="text" indexed="true" stored="true" multiValued="false"/>
+    <dynamicField name="res_extras_*" type="text" indexed="true" stored="true" multiValued="true"/>
+    <dynamicField name="vocab_*" type="string" indexed="true" stored="true" multiValued="true"/>
+    <dynamicField name="*" type="string" indexed="true"  stored="false"/>
+
+    <!-- Custom metadata schema -->
+    <field name="topics" type="string" indexed="true" stored="true" multiValued="false"/>
+    <field name="geographies" type="string" indexed="true" stored="true" multiValued="false"/>
+    <field name="regions" type="string" indexed="true" stored="true" multiValued="false"/>
+    <field name="sectors" type="string" indexed="true" stored="true" multiValued="false"/>
+    <field name="modes" type="string" indexed="true" stored="true" multiValued="false"/>
+    <field name="services" type="string" indexed="true" stored="true" multiValued="false"/>
+    <field name="contributors" type="string" indexed="true" stored="true" multiValued="false"/>
+    <field name="is_archived" type="boolean" indexed="true" stored="true" />
+
+    
+</fields>
+
+<uniqueKey>index_id</uniqueKey>
+
+<copyField source="url" dest="urls"/>
+<copyField source="title" dest="title_ngram"/>
+<copyField source="name" dest="name_ngram"/>
+<copyField source="ckan_url" dest="urls"/>
+<copyField source="download_url" dest="urls"/>
+<copyField source="res_url" dest="urls"/>
+<copyField source="extras_*" dest="text"/>
+<copyField source="res_extras_*" dest="text"/>
+<copyField source="vocab_*" dest="text"/>
+<copyField source="urls" dest="text"/>
+<copyField source="name" dest="text"/>
+<copyField source="title" dest="text"/>
+<copyField source="text" dest="text"/>
+<copyField source="license" dest="text"/>
+<copyField source="notes" dest="text"/>
+<copyField source="tags" dest="text"/>
+<copyField source="groups" dest="text"/>
+<copyField source="organization" dest="text"/>
+<copyField source="res_name" dest="text"/>
+<copyField source="res_description" dest="text"/>
+<copyField source="maintainer" dest="text"/>
+<copyField source="author" dest="text"/>
+
+</schema>


### PR DESCRIPTION
## Important notes

- Do not deploy this to prod until the changes are replicated to the prod dockerfile.
- Facets won't work until we have the custom SOLR schema (to test the facets I changed the SOLR schema via UI)
- `package_search` now has a new parameter - `include_archived`. It defaults to `false` and can be set to true in order to fetch archived datasets.
- Every time a user updates a dataset, the `contributors` field is updated. This field will be faceted when the custom SOLR schema is put in place.
- Do not use the `groups` field for groups.
  - For topics, use the `topics` field. Simply a list of topic names e.g. `["my-topic"] `
  - For geographies, use the `geographies` field c.f. topics :arrow_up: . Note that regions are assigned automatically based on the geographies.
  
## General guidelines for using the metadata schema

- Use the documentation on this PR as the main reference. The spreadsheet should serve for historical purposes.
- `ckanext-scheming` provides some endpoints to get the schema file for entities. **I would like to suggest that we put as much as possible of the field properties on the JSON schema files and fetch that on the front end when building forms**. 
  - This would enforce a single source of truth for the metadata of the fields themselves, and avoid duplication/rework. 
  - For example, if you want to make a dataset field required, specify it on the `dataset.yaml` file and parse that on the front end. This way API also gets validation and the JSON schema becomes more complete.
  - Another very good use case is that you can fetch select input options from the JSON schema. This means that in the future, if the client wants to update the list of options, they can do it in a single place and it will reflect both on the API and on the front end.
  - Note that you can add custom fields to the JSON schema. Other use cases:
    - Placeholder text
    - Default values (when static)
    - Labels
- Language field - We should use ISO 639-1 values. There are too many options to put on the JSON schema, so I kept it as a string field. See JSON schema for references on where to get the possible options.
- The documentation is focused on fields that are used to create a dataset, some other fields are automatically calculated e.g. regions

## Changes to the local environment

Update your .env file with the following new env vars: (and make sure to rebuild the docker image)

```bash
CKAN___SCHEMING__DATASET_SCHEMAS=ckanext.tdc:schemas/dataset.yaml
CKAN___SCHEMING__GROUP_SCHEMAS="ckanext.tdc:schemas/topic.yaml ckanext.tdc:schemas/geography.yaml"
CKAN___SCHEMING__ORGANIZATION_SCHEMAS="ckanext.tdc:schemas/organization.yaml"
CKAN___SCHEMING__PRESETS="ckanext.tdc:schemas/presets.yaml"
CKAN__DEFAULT__GROUP_TYPE=topic
CKAN__PLUGINS="tdc hierarchy_display scheming_datasets scheming_groups scheming_organizations dcat envvars image_view text_view activity auth s3filestore datastore datapusher resource_proxy"
```