### PR TITLE
Newsfeed Page fixes

### DIFF
--- a/docs/newsfeed/README.md
+++ b/docs/newsfeed/README.md
@@ -4,7 +4,7 @@ The newsfeed page shows the activity regarding organizations that a user is a me
 
 ![NewsFeed Page](page.png)
 
-User can search by activity type and name.
+User can search by activity type/name, Dataset name and title, Organization name and title, and actor.
 
 ![Search](search.png)
 
@@ -14,6 +14,8 @@ User can filter activities based on four categories:
 - Organizations
 - Datasets
 - Dataset Approvals
+
+`Note:` For now Datasets and Dataset Approvals are doing the exact same thing (filtering on Datasets) because the Dataset Approval flow is not implemented yet. //TODO remove this in future.
 
 ![Filter](filter.png)
 

--- a/frontend/src/components/dashboard/NewsFeedTabContent.tsx
+++ b/frontend/src/components/dashboard/NewsFeedTabContent.tsx
@@ -42,7 +42,12 @@ export interface NewsFeedCardProps {
   activity_type: string;
 }
 export default () => {
-  const filterOptions = ["All", "Organizations", "Dataset", "Dataset Approval"];
+  const filterOptions = [
+    "All",
+    "Organizations",
+    "Datasets",
+    "Datasets Approvals",
+  ];
   const [searchText, setSearchText] = useState("");
   const [filter, setFilter] = useState("All");
   const [sortOrder, setSortOrder] = useState("latest");
@@ -56,14 +61,47 @@ export default () => {
   const { data: activities, isLoading } =
     api.user.listUserActivities.useQuery();
 
+  const preprocessedActivities = activities?.map((activity: any) => {
+    const activitySegments = activity.activity_type?.split(" ");
+    const activityType = activitySegments ? activitySegments[0] : "changed";
+    const activityTarget = activitySegments
+      ? activitySegments[1] === "package"
+        ? "dataset"
+        : activitySegments[1]
+      : "entity";
+
+    // Add synonyms for activity type and target
+    const mappedActivityType =
+      activityType === "changed" ? "updated" : activityType;
+    const mappedActivityTarget =
+      activityTarget === "dataset" ? "package" : activityTarget;
+
+    return {
+      ...activity,
+      "data.group.title": activity.data?.group?.title || "",
+      "data.group.name": activity.data?.group?.name || "",
+      "data.package.name": activity.data?.package?.name || "",
+      "data.package.title": activity.data?.package?.title || "",
+      "data.actor": activity.data?.actor || "",
+      activity_type_synonym: `${activityType} ${activityTarget} ${mappedActivityType} ${mappedActivityTarget}`,
+    };
+  });
+
   const miniSearch = useMemo(() => {
     const search = new MiniSearch({
-      fields: ["activity_type"],
+      fields: [
+        "activity_type_synonym",
+        "data.group.title",
+        "data.group.name",
+        "data.package.name",
+        "data.package.title",
+        "data.actor",
+      ],
       storeFields: ["id", "timestamp", "user_id", "activity_type", "data"],
     });
-    search.addAll(activities || []);
+    search.addAll(preprocessedActivities || []);
     return search;
-  }, [activities]);
+  }, [preprocessedActivities]);
 
   const searchResults = useMemo(() => {
     const filteredActivites = activities?.filter((item) =>


### PR DESCRIPTION
This PR includes.

- Fix the quick filter on top of the page when filtered by Datasets and Dataset Approvals.
- Enhanced search bar functionality:
Previously it was only searching for activity type and name. 
Now it can be searched for:

1. Activity type/name 
2. Datasets/Organizations name and title
3. Activity actor.

**Note:** For now the `Datasets` and `Dataset Approvals` filters are doing the same thing, because the Dataset approval flow is not implemented yet. 