### PR TITLE
Add integration test for partners page

### DIFF
--- a/frontend/cypress/e2e/partners-donors.cy.js
+++ b/frontend/cypress/e2e/partners-donors.cy.js
@@ -1,0 +1,19 @@
+
+import partners from '../../src/data/partners.json';
+
+
+describe("List partners and donors", () => {
+  const firstPartner = partners[0];
+  
+  it("show partner title, image and website", () => {
+    
+    cy.visit(`/partners`);
+    
+    cy.get('.grid img').should('have.attr', 'src', firstPartner.image) 
+    cy.contains(firstPartner.name) 
+    cy.get(`.grid a[href="${firstPartner.url}"]`) 
+      
+  });
+
+
+});


### PR DESCRIPTION
Issue: https://github.com/transport-data/tdc-data-portal/issues/57
Test if partners listed in `partenrs.json` are present in partners page