### PR TITLE
ci: pin Node 20 to fix sqlite3 build

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,6 +17,10 @@ jobs:
     steps:
       - name: Git clone the repository
         uses: actions/checkout@v3
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
       - name: Add CKAN url to hosts
         run: sudo echo "127.0.0.1 ckan-dev" | sudo tee -a /etc/hosts
       - name: Add Minio url to hosts


### PR DESCRIPTION
CI was failing in the `Run frontend tests` step with npm exit code 7 — not a Cypress assertion failure.

Root cause: GitHub runners now default to Node 22. `sqlite3@5.1.7` (transitive via `@portaljs/mddb`) has no prebuilt N-API binary advertised for Node 22, so npm falls back to `node-gyp@8.4.1`. That node-gyp's bundled `cacache` calls `util.promisify` on a non-function under Node 22 and crashes before Cypress ever runs:

```
npm error gyp ERR! stack TypeError [ERR_INVALID_ARG_TYPE]: The "original" argument must be of type function
  at Object.promisify (node:internal/util:448:3)
  at .../node_modules/cacache/lib/verify.js:10:19
node -v v22.22.3
```

Fix: pin Node 20 with `actions/setup-node@v4` before the cypress action runs. `sqlite3@5.1.7` has prebuilt binaries for Node 20, install succeeds, tests actually execute.

Reference failing run: https://github.com/transport-data/portal/actions/runs/27131207175