### PR TITLE
Add show more/less toggle for organization descriptions

### DIFF
--- a/frontend/src/components/organization/individualPage/OrgInfo.tsx
+++ b/frontend/src/components/organization/individualPage/OrgInfo.tsx
@@ -1,11 +1,15 @@
+import { useState } from "react";
 import Image from "next/image";
 import { format } from "timeago.js";
 import { Tag } from "@portaljs/ckan";
 import { Organization } from "@portaljs/ckan";
 
 export default function OrgInfo({ org }: { org: Organization }) {
+  const [isExpanded, setIsExpanded] = useState(false);
   const packageCount = (org as Organization & { package_count?: number })
     .package_count;
+  const descriptionText = org.description?.replace(/<\/?[^>]+(>|$)/g, "") || "No description";
+  const shouldShowToggle = descriptionText.length > 180;
 
   return (
     <div className="flex flex-col">
@@ -54,9 +58,22 @@ export default function OrgInfo({ org }: { org: Organization }) {
         </span>
       </div>
       <div className="my-4 border-y py-4">
-        <p className="line-clamp-4 text-sm font-normal text-stone-500">
-          {org.description?.replace(/<\/?[^>]+(>|$)/g, "") || "No description"}
+        <p
+          className={`text-sm font-normal text-stone-500 whitespace-pre-line ${
+            isExpanded ? "" : "line-clamp-4"
+          }`}
+        >
+          {descriptionText}
         </p>
+        {shouldShowToggle && (
+          <button
+            type="button"
+            onClick={() => setIsExpanded((prev) => !prev)}
+            className="mt-2 text-sm font-medium text-accent underline-offset-2 hover:underline"
+          >
+            {isExpanded ? "Show less" : "Show more"}
+          </button>
+        )}
       </div>
       <div className="flex flex-wrap gap-1">
         {org.tags?.map((tag: Tag) => (


### PR DESCRIPTION
This fixes https://github.com/datopian/Support-Services/issues/874#issuecomment-4956082790

Previously it looked

<img width="974" height="460" alt="image" src="https://github.com/user-attachments/assets/7aa467b7-b04d-4c04-b650-c7612b747725" />

After fixing it looks

<img width="320" height="383" alt="image" src="https://github.com/user-attachments/assets/bd44f90a-1b6d-431f-8407-ecfd943de19f" />


## Summary
This PR adds a Show more / Show less toggle for organization descriptions on the organization detail page.

## What changed
- Updated the organization sidebar description block to show a collapsed preview for long text
- Added an interactive toggle so reviewers can expand or collapse the full description
- Preserved the existing behavior for shorter descriptions

## Why
Long organization descriptions were being visually cut off in the sidebar. This change improves readability without sacrificing layout or page structure.

## Notes
- No backend changes were required
- The change is scoped to the organization info component only